### PR TITLE
Change  dbsnp2 notebooks to use Python 3

### DIFF
--- a/tutorials/Variation Services/Jupyter_Notebook/README.md
+++ b/tutorials/Variation Services/Jupyter_Notebook/README.md
@@ -1,45 +1,62 @@
 # Variation services Notebooks
 
-You can launch a live Jupyter Notebook in your web browser using `Binder` (beta) below to test and experiment.
-The experimental `Binder` server may take a few minutes to launch and can be slow, run out of memory, and may not always work.
+You can launch most of the Jupyter Notebooks here in your web browser using
+`Binder` (beta) to test and experiment. The experimental `Binder` server may
+take a few minutes to launch and can be slow, run out of memory, and may not
+always work.
 
 ## `SPDI` notebooks
 
-* Launch `spdi_batch.ipynb` notebook on Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=%2Ftutorials%2FVariation%20Services%2FJupyter_Notebook%2Fspdi_batch.ipynb)
+* Launch `spdi_batch.ipynb` notebook on Binder:
+  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=%2Ftutorials%2FVariation%20Services%2FJupyter_Notebook%2Fspdi_batch.ipynb)
 
-Batch rs ID annotation and conversion HGVS to SPDI, HGVS to RS ID, and retrieve RS JSON objects using Variation Services.
+Batch rs ID annotation and conversion HGVS to SPDI, HGVS to RS ID, and retrieve
+RS JSON objects using Variation Services.
 
-* Launch `navs_spdi_demo.ipynb` notebook on Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fnavs_spdi_demo.ipynb)
+* Launch `navs_spdi_demo.ipynb` notebook on Binder:
+  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fnavs_spdi_demo.ipynb)
 
-Use NCBI API Variation Service (navs) module to convert variant notations (HGVS, RS, and SPDI), remap variants between sequences, and normalized variants.
+Use NCBI API Variation Service (navs) module to convert variant notations (HGVS,
+RS, and SPDI), remap variants between sequences, and normalized variants.
 
 ## The Allele Frequency Aggregator (ALFA) project's notebooks
 
-* Launch `by_gene.ipynb` notebook on Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fby_gene.ipynb)
+* Launch `by_gene.ipynb` notebook on Binder:
+  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fby_gene.ipynb)
 
 Retrieve frequency data by gene using eUtils and Variation Service
 
-* Launch `by_rsid.ipynb` notebook on Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fby_rsid.ipynb)
+* Launch `by_rsid.ipynb` notebook on Binder:
+  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fby_rsid.ipynb)
 
 Retrieve frequency data by rsid in JSON format
 
-* Launch `frequencies_for_vcf.ipynb` notebook on Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Ffrequencies_for_vcf.ipynb)
+* Launch `frequencies_for_vcf.ipynb` notebook on Binder:
+  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Ffrequencies_for_vcf.ipynb)
 
 Compare frequencies for two populations for variations from a VCF file
 
-* Launch `metadata_as_hash.ipynb` notebook on Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fmetadata_as_hash.ipynb)
+* Launch `metadata_as_hash.ipynb` notebook on Binder:
+  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fmetadata_as_hash.ipynb)
+
 Retrieve and transform ALFA project and population meta data
 
-* Launch `plot.ipynb` notebook on Binder: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fplot.ipynb)
+* Launch `plot.ipynb` notebook on Binder:
+  [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ncbi/dbsnp/master?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fplot.ipynb)
 
 Plot population minor allele frequencies (MAFs) for variants in a gene location
 
-* Launch `querying_subsets_ftp.ipynb` notebook on [Google Colab](https://colab.research.google.com/github/ncbi/dbsnp/blob/master/tutorials/Variation%20Services/Jupyter_Notebook/querying_subsets_ftp.ipynb)
+* Launch `querying_subsets_ftp.ipynb` notebook on [Google
+  Colab](https://colab.research.google.com/github/ncbi/dbsnp/blob/master/tutorials/Variation%20Services/Jupyter_Notebook/querying_subsets_ftp.ipynb)
 
-Retrieving subsets of VCF data from remote NCBI FTP site
+Retrieve subsets of VCF data from the NCBI FTP site.
 
-    Notes:
+## Execution environments
 
-    * A (free) Google account is required to run a notebook in Google Colab.
+Unless otherwise noted, the notebooks can be executed in `Binder` as mentioned
+earlier. But `querying_subsets_ftp.ipynb` needs to be executed in Google Colab
+because it needs FTP access and `Binder` has a policy of not allowing FTP
+connections:
+<https://github.com/binder-examples/getting-data#large-public-files>
 
-    * We do not use Binder for this notebook because they have a policy of not allowing FTP connections: <https://github.com/binder-examples/getting-data#large-public-files>
+A (free) Google account is required to run a notebook in Google Colab.

--- a/tutorials/Variation Services/Jupyter_Notebook/navs_spdi_demo.ipynb
+++ b/tutorials/Variation Services/Jupyter_Notebook/navs_spdi_demo.ipynb
@@ -289,25 +289,25 @@
    "source": []
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "mimetype": "text/x-python",
+      "nbconvert_exporter": "python",
+      "name": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.2",
+      "file_extension": ".py"
+    }
   },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.7"
-  }
- },
  "nbformat": 4,
  "nbformat_minor": 1
 }

--- a/tutorials/Variation Services/Jupyter_Notebook/spdi_batch.ipynb
+++ b/tutorials/Variation Services/Jupyter_Notebook/spdi_batch.ipynb
@@ -89,21 +89,21 @@
   ],
   "metadata": {
     "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2",
-      "language": "python"
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
     },
     "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
       "mimetype": "text/x-python",
       "nbconvert_exporter": "python",
       "name": "python",
-      "pygments_lexer": "ipython2",
-      "version": "2.7.15",
-      "file_extension": ".py",
-      "codemirror_mode": {
-        "version": 2,
-        "name": "ipython"
-      }
+      "pygments_lexer": "ipython3",
+      "version": "3.6.2",
+      "file_extension": ".py"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
Note that the URLs in the `README` always point to `master`. So, to test them in `Binder` you need these URLs with the correct branch name:

https://mybinder.org/v2/gh/ncbi/dbsnp/upgrade_to_python3?filepath=%2Ftutorials%2FVariation%20Services%2FJupyter_Notebook%2Fspdi_batch.ipynb

https://mybinder.org/v2/gh/ncbi/dbsnp/upgrade_to_python3?filepath=tutorials%2FVariation%20Services%2FJupyter_Notebook%2Fnavs_spdi_demo.ipynb